### PR TITLE
fix: argocd-agent addon needs a temporary workaround

### DIFF
--- a/argocd-agent-addon/charts/argocd-addon/templates/argocd-addon-template.yaml
+++ b/argocd-agent-addon/charts/argocd-addon/templates/argocd-addon-template.yaml
@@ -6828,6 +6828,8 @@ spec:
             labels:
               app.kubernetes.io/name: argocd-secret
               app.kubernetes.io/part-of: argocd
+          data:
+            server.secretkey: Zm9v # dummy key workaround for https://github.com/argoproj/argo-cd/issues/22931
           type: Opaque
         - apiVersion: v1
           kind: ConfigMap

--- a/argocd-agent-addon/charts/argocd-addon/values.yaml
+++ b/argocd-agent-addon/charts/argocd-addon/values.yaml
@@ -1,4 +1,4 @@
 argocd:
   image:
     repository: quay.io/argoproj/argocd
-    tag: v2.13.1
+    tag: v3.0.6


### PR DESCRIPTION
fix: argocd-agent addon needs a temporary workaround to get the Application reconcile successfully on the spoke. Also update the argocd version to v3.0.6.