### PR TITLE
Allow IP address configuration for NodePort FL listeners

### DIFF
--- a/federated-learning-controller/README.md
+++ b/federated-learning-controller/README.md
@@ -58,8 +58,8 @@ cluster2   true           https://cluster2-control-plane:6443   True     True   
 #### 1. Clone and navigate to the repository
 
 ```bash
-git@github.com:open-cluster-management-io/addon-contrib.git
-cd federated-learning-controller
+git clone git@github.com:open-cluster-management-io/addon-contrib.git
+cd ./addon-contrib/federated-learning-controller
 ```
 
 #### 2. Build and push the controller image

--- a/federated-learning-controller/api/v1alpha1/federatedlearning_types.go
+++ b/federated-learning-controller/api/v1alpha1/federatedlearning_types.go
@@ -102,6 +102,11 @@ type ListenerSpec struct {
 	// +kubebuilder:default:=8080
 	Port int          `json:"port,omitempty"`
 	Type ListenerType `json:"type,omitempty"`
+	
+	// IP is the optional bind IP for NodePort services.
+	// It is only applicable when Type is "NodePort".
+	// +optional
+	IP string `json:"ip,omitempty"`
 }
 
 // FederatedLearningStatus defines the observed state of FederatedLearning.

--- a/federated-learning-controller/config/crd/bases/federation-ai.open-cluster-management.io_federatedlearnings.yaml
+++ b/federated-learning-controller/config/crd/bases/federation-ai.open-cluster-management.io_federatedlearnings.yaml
@@ -546,6 +546,11 @@ spec:
                     items:
                       description: ListenerSpec defines the specification for a listener.
                       properties:
+                        ip:
+                          description: |-
+                            IP is the optional bind IP for NodePort services.
+                            It is only applicable when Type is "NodePort".
+                          type: string
                         name:
                           type: string
                         port:

--- a/federated-learning-controller/internal/controller/federatedlearning_controller.go
+++ b/federated-learning-controller/internal/controller/federatedlearning_controller.go
@@ -120,7 +120,7 @@ func (r *FederatedLearningReconciler) Reconcile(ctx context.Context, req ctrl.Re
 		// 1. server: storage, job (rounds, minAvailableClients)
 		if err := r.federatedLearningServer(ctx, instance); err != nil {
 			log.Errorf("failed to create/update the server: %v", err)
-			return ctrl.Result{}, err
+			return ctrl.Result{RequeueAfter: 5 * time.Second}, nil
 		}
 
 		// 2. client: placement(based on selected cluster -> Running), Running -> generate manifestwork

--- a/federated-learning-controller/internal/controller/federatedlearning_server.go
+++ b/federated-learning-controller/internal/controller/federatedlearning_server.go
@@ -38,19 +38,33 @@ func (r *FederatedLearningReconciler) federatedLearningServer(ctx context.Contex
 	if instance.DeletionTimestamp != nil {
 		return nil
 	}
-	if err := r.storage(ctx, instance); err != nil {
-		return err
-	}
 
 	if len(instance.Spec.Server.Listeners) == 0 {
 		return fmt.Errorf("no listeners specified")
+	}
+
+	var err error
+
+	defer func() {
+		if err != nil {
+			instance.Status.Message = fmt.Sprintf("failed to initialize the server resources: %s", err.Error())
+			if updateErr := r.Status().Update(ctx, instance); updateErr != nil {
+				log.Errorw("failed to update the instance status", "error", updateErr)
+			}
+			return
+		}
+	}()
+
+	if err = r.storage(ctx, instance); err != nil {
+		return err
 	}
 
 	// instance.Spec.Server.Listeners[0].Type != flv1alpha1.Route
 	// route is http based -> requires to handle the transport: https://flower.ai/docs/framework/ref-api/flwr.client.start_client.html
 	if instance.Spec.Server.Listeners[0].Type != flv1alpha1.LoadBalancer &&
 		instance.Spec.Server.Listeners[0].Type != flv1alpha1.NodePort {
-		return fmt.Errorf("unsupported listener type: %s", instance.Spec.Server.Listeners[0].Type)
+		err = fmt.Errorf("unsupported listener type: %s", instance.Spec.Server.Listeners[0].Type)
+		return err
 	}
 
 	createService := false
@@ -64,7 +78,8 @@ func (r *FederatedLearningReconciler) federatedLearningServer(ctx context.Contex
 		if errors.IsNotFound(err) {
 			createService = true
 		} else {
-			return fmt.Errorf("failed to get service: %w", err)
+			err = fmt.Errorf("failed to get service: %w", err)
+			return err
 		}
 	} else {
 		// if service already exists, check if the type is correct
@@ -107,7 +122,7 @@ func (r *FederatedLearningReconciler) federatedLearningServer(ctx context.Contex
 
 	// create restmapper for deployer to find GVR
 	mapper := restmapper.NewDeferredDiscoveryRESTMapper(memory.NewMemCacheClient(dc))
-	if err := SetOwner(unstructuredObjects, instance, mapper, r.Scheme); err != nil {
+	if err = SetOwner(unstructuredObjects, instance, mapper, r.Scheme); err != nil {
 		return err
 	}
 
@@ -117,7 +132,7 @@ func (r *FederatedLearningReconciler) federatedLearningServer(ctx context.Contex
 		}
 	}
 
-	if err := r.updateServerAddress(ctx, instance); err != nil {
+	if err = r.updateServerAddress(ctx, instance); err != nil {
 		return err
 	}
 
@@ -195,8 +210,7 @@ func (r *FederatedLearningReconciler) updateRoute(ctx context.Context, svc *core
 func (r *FederatedLearningReconciler) updateLB(ctx context.Context, svc *corev1.Service, instance *flv1alpha1.FederatedLearning) error {
 	log.Info("loadBalancer service found")
 	if len(svc.Status.LoadBalancer.Ingress) == 0 {
-		log.Info("loadBalancer service address is empty")
-		return nil
+		return fmt.Errorf("loadBalancer service address is empty for %s/%s", svc.Namespace, svc.Name)
 	}
 
 	var address string

--- a/federated-learning-controller/internal/controller/manifests/config.go
+++ b/federated-learning-controller/internal/controller/manifests/config.go
@@ -11,6 +11,7 @@ type FederatedLearningServerParams struct {
 	InitModel           string
 	ListenerType        string
 	ListenerPort        int
+	CreateService       bool
 }
 
 type FederatedLearningClientParams struct {

--- a/federated-learning-controller/internal/controller/manifests/server/service.yaml
+++ b/federated-learning-controller/internal/controller/manifests/server/service.yaml
@@ -1,4 +1,4 @@
-{{- if or (eq .ListenerType "NodePort") (eq .ListenerType "LoadBalancer") }}
+{{- if and .CreateService (or (eq .ListenerType "NodePort") (eq .ListenerType "LoadBalancer") ) }}
 apiVersion: v1
 kind: Service
 metadata:


### PR DESCRIPTION
Updates: 

1. Allow IP address configuration for NodePort FL listeners.
2. When creating a Service of type LoadBalancer or NodePort, ensure it remains modifiable by other controllers and does not override their configurations.
