### PR TITLE
argocd-agent addon fix: use the same image and rbac adjustment

### DIFF
--- a/argocd-agent-addon/charts/argocd-agent-addon/templates/agent-addon/argocd-agent-addon-template.yaml
+++ b/argocd-agent-addon/charts/argocd-agent-addon/templates/agent-addon/argocd-agent-addon-template.yaml
@@ -41,13 +41,7 @@ spec:
           rules:
             - apiGroups: [""]
               resources: [namespaces]
-              verbs: [get, list, watch]
-            - apiGroups: [argoproj.io]
-              resources: [appprojects]
-              verbs: [get, list, watch]
-            - apiGroups: [argoproj.io]
-              resources: [applications]
-              verbs: [create, get, list, watch, update, delete, patch]
+              verbs: [list, watch]
         - apiVersion: apps/v1
           kind: Deployment
           metadata:
@@ -71,7 +65,7 @@ spec:
               spec:
                 containers:
                   - args:
-                      - /usr/local/bin/argocd-agent-agent
+                      - agent
                     env:
                     - name: ARGOCD_AGENT_REMOTE_SERVER
                       valueFrom:
@@ -133,7 +127,7 @@ spec:
                           name: argocd-agent-params
                           key: agent.creds
                           optional: true
-                    image: {{ .Values.global.imageOverrides.agentAgentImage }}
+                    image: {{ .Values.global.imageOverrides.argocdAgentImage }}
                     imagePullPolicy: {{ .Values.global.imagePullPolicy }}
                     name: argocd-agent-agent
                     ports:

--- a/argocd-agent-addon/charts/argocd-agent-addon/templates/principal/principal-clusterrole.yaml
+++ b/argocd-agent-addon/charts/argocd-agent-addon/templates/principal/principal-clusterrole.yaml
@@ -8,14 +8,6 @@ metadata:
   name: argocd-agent-principal
 rules:
 - apiGroups:
-  - ""
-  resources:
-  - namespaces
-  verbs:
-  - get
-  - list
-  - watch
-- apiGroups:
   - argoproj.io
   resources:
   - applications
@@ -29,3 +21,12 @@ rules:
   - update
   - delete
   - patch
+- apiGroups:
+  - ""
+  resources:
+  - namespaces
+  verbs:
+  - create
+  - get
+  - list
+  - watch

--- a/argocd-agent-addon/charts/argocd-agent-addon/templates/principal/principal-deployment.yaml
+++ b/argocd-agent-addon/charts/argocd-agent-addon/templates/principal/principal-deployment.yaml
@@ -20,7 +20,7 @@ spec:
     spec:
       containers:
         - args:
-            - /usr/local/bin/argocd-agent-principal
+            - principal
           env:
           - name: ARGOCD_PRINCIPAL_ENABLE_RESOURCE_PROXY
             value: "false"
@@ -138,7 +138,7 @@ spec:
                 name: argocd-agent-params
                 key: principal.auth
                 optional: true
-          image: {{ .Values.global.imageOverrides.agentPrincipalImage }}
+          image: {{ .Values.global.imageOverrides.argocdAgentImage }}
           imagePullPolicy: {{ .Values.global.imagePullPolicy }}
           name: argocd-agent-principal
           ports:

--- a/argocd-agent-addon/charts/argocd-agent-addon/values.yaml
+++ b/argocd-agent-addon/charts/argocd-agent-addon/values.yaml
@@ -1,7 +1,6 @@
 global:
   imageOverrides:
-    agentPrincipalImage: ghcr.io/argoproj-labs/argocd-agent/argocd-agent-principal:latest
-    agentAgentImage: ghcr.io/argoproj-labs/argocd-agent/argocd-agent-agent:latest
+    argocdAgentImage: ghcr.io/argoproj-labs/argocd-agent/argocd-agent:latest
   imagePullPolicy: IfNotPresent
 
 agent:


### PR DESCRIPTION
argocd-agent addon fix: 
- use the same image for both principal and agent components.
- adjust rbac based on recent argocd-agent upstream changes