### PR TITLE
:sparkles: Enable Multi-Arch Docker Image Support (amd64 & arm64) for FL demo

### DIFF
--- a/federated-learning-controller/Makefile
+++ b/federated-learning-controller/Makefile
@@ -112,6 +112,15 @@ docker-build: ## Build docker image with the manager.
 docker-push: ## Push docker image with the manager.
 	$(CONTAINER_TOOL) push ${IMG}
 
+# docker run --rm --privileged tonistiigi/binfmt --install all
+.PHONY: docker-platform-build
+docker-platform-build: ## Build docker image for multiple platforms (linux/amd64,linux/arm64).
+	$(CONTAINER_TOOL) buildx build --platform linux/amd64,linux/arm64 -t ${IMG} .
+
+.PHONY: docker-platform-push
+docker-platform-push: ## Build and push docker image for multiple platforms (linux/amd64,linux/arm64).
+	$(CONTAINER_TOOL) buildx build --platform linux/amd64,linux/arm64 --push -t ${IMG} .
+
 # PLATFORMS defines the target platforms for the manager image be built to provide support to multiple
 # architectures. (i.e. make docker-buildx IMG=myregistry/mypoperator:0.0.1). To use this option you need to:
 # - be able to use docker buildx. More info: https://docs.docker.com/build/buildx/

--- a/federated-learning-controller/examples/flower/Makefile
+++ b/federated-learning-controller/examples/flower/Makefile
@@ -1,15 +1,37 @@
-
 # Variables
 REGISTRY ?= quay.io/open-cluster-management
 IMAGE_TAG ?= latest
 DIST_DIR = dist
 APP = app-torch
+PLATFORMS ?= linux/amd64,linux/arm64
+IMAGE_FULL_NAME = ${REGISTRY}/flower-${APP}:${IMAGE_TAG}
 
+# Single-arch build (local)
 build-app-image:
-	cd ${APP} && docker build -t ${REGISTRY}/flower-${APP}:${IMAGE_TAG} . -f Dockerfile && cd ..
+	cd ${APP} && docker build -t ${IMAGE_FULL_NAME} . -f Dockerfile && cd ..
 
+# Single-arch push
 push-app-image:
-	docker push ${REGISTRY}/flower-${APP}:${IMAGE_TAG}
+	docker push ${IMAGE_FULL_NAME}
 
+# Multi-arch build without push (export to local registry/engine not supported directly)
+build-platform-image:
+	cd ${APP} && \
+	docker buildx build \
+		--platform ${PLATFORMS} \
+		--tag ${IMAGE_FULL_NAME} \
+		--output=type=docker \
+		. -f Dockerfile && cd ..
+
+# Multi-arch push (requires --push during buildx)
+push-platform-image:
+	cd ${APP} && \
+	docker buildx build \
+		--platform ${PLATFORMS} \
+		--tag ${IMAGE_FULL_NAME} \
+		--push \
+		. -f Dockerfile && cd ..
+
+# Clean
 clean:
 	rm -rf $(DIST_DIR) __pycache__ *.spec

--- a/federated-learning-controller/go.mod
+++ b/federated-learning-controller/go.mod
@@ -3,14 +3,17 @@ module github/open-cluster-management/federated-learning
 go 1.23.0
 
 require (
+	github.com/go-logr/logr v1.4.2
+	github.com/go-logr/zapr v1.3.0
 	github.com/onsi/ginkgo/v2 v2.21.0
 	github.com/onsi/gomega v1.35.1
+	github.com/openshift/api v0.0.0-20240527133614-ba11c1587003
 	github.com/openshift/library-go v0.0.0-20240723172506-8bb8fe6cc56d
 	github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring v0.79.2
+	go.uber.org/zap v1.27.0
 	k8s.io/api v0.32.0
 	k8s.io/apimachinery v0.32.0
 	k8s.io/client-go v0.32.0
-	k8s.io/klog/v2 v2.130.1
 	open-cluster-management.io/api v0.15.0
 	sigs.k8s.io/controller-runtime v0.19.3
 )
@@ -29,9 +32,7 @@ require (
 	github.com/felixge/httpsnoop v1.0.4 // indirect
 	github.com/fsnotify/fsnotify v1.7.0 // indirect
 	github.com/fxamacker/cbor/v2 v2.7.0 // indirect
-	github.com/go-logr/logr v1.4.2 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
-	github.com/go-logr/zapr v1.3.0 // indirect
 	github.com/go-openapi/jsonpointer v0.21.0 // indirect
 	github.com/go-openapi/jsonreference v0.20.2 // indirect
 	github.com/go-openapi/swag v0.23.0 // indirect
@@ -52,7 +53,6 @@ require (
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
-	github.com/openshift/api v0.0.0-20240527133614-ba11c1587003 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/prometheus/client_golang v1.19.1 // indirect
 	github.com/prometheus/client_model v0.6.1 // indirect
@@ -71,7 +71,6 @@ require (
 	go.opentelemetry.io/otel/trace v1.28.0 // indirect
 	go.opentelemetry.io/proto/otlp v1.3.1 // indirect
 	go.uber.org/multierr v1.11.0 // indirect
-	go.uber.org/zap v1.27.0 // indirect
 	golang.org/x/exp v0.0.0-20240719175910-8a7402abbf56 // indirect
 	golang.org/x/net v0.32.0 // indirect
 	golang.org/x/oauth2 v0.23.0 // indirect
@@ -92,6 +91,7 @@ require (
 	k8s.io/apiextensions-apiserver v0.32.0 // indirect
 	k8s.io/apiserver v0.32.0 // indirect
 	k8s.io/component-base v0.32.0 // indirect
+	k8s.io/klog/v2 v2.130.1 // indirect
 	k8s.io/kube-openapi v0.0.0-20241105132330-32ad38e42d3f // indirect
 	k8s.io/utils v0.0.0-20241210054802-24370beab758 // indirect
 	sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.31.0 // indirect


### PR DESCRIPTION
Add support for building and pushing multi-architecture Docker images (linux/amd64, linux/arm64) using docker buildx.
This allows the image to run seamlessly on both x86 (Linux) and Apple Silicon (macOS) environments.