### PR TITLE
✨ DSF: Support Extra Volumes Injection for hub components

### DIFF
--- a/dynamic-scoring-framework/charts/dynamic-scoring-framework/templates/addon-controller.yaml
+++ b/dynamic-scoring-framework/charts/dynamic-scoring-framework/templates/addon-controller.yaml
@@ -23,6 +23,18 @@ spec:
         args:
           - "/dynamic-scoring-addon"
           - "controller"
+        volumeMounts:
+        {{- with .Values.hubSetting.extraVolumeMounts }}
+{{ toYaml . | nindent 10 }}
+        {{- else }}
+          []
+        {{- end }}
+      volumes:
+      {{- with .Values.hubSetting.extraVolumes }}
+{{ toYaml . | nindent 8 }}
+      {{- else }}
+        []
+      {{- end }}
 ---
 apiVersion: v1
 kind: ServiceAccount

--- a/dynamic-scoring-framework/charts/dynamic-scoring-framework/templates/dynamic-scoring-controller.yaml
+++ b/dynamic-scoring-framework/charts/dynamic-scoring-framework/templates/dynamic-scoring-controller.yaml
@@ -392,11 +392,21 @@ spec:
           capabilities:
             drop:
             - ALL
-        volumeMounts: []
+        volumeMounts:
+        {{- with .Values.hubSetting.extraVolumeMounts }}
+{{ toYaml . | nindent 10 }}
+        {{- else }}
+          []
+        {{- end }}
       securityContext:
         runAsNonRoot: true
         seccompProfile:
           type: RuntimeDefault
       serviceAccountName: dynamic-scoring-framework-controller
       terminationGracePeriodSeconds: 10
-      volumes: []
+      volumes:
+      {{- with .Values.hubSetting.extraVolumes }}
+{{ toYaml . | nindent 8 }}
+      {{- else }}
+        []
+      {{- end }}

--- a/dynamic-scoring-framework/charts/dynamic-scoring-framework/values.yaml
+++ b/dynamic-scoring-framework/charts/dynamic-scoring-framework/values.yaml
@@ -1,4 +1,26 @@
 hubSetting:
+  # Additional pod volumes applied to all hub controller Deployments.
+  # Example:
+  # extraVolumes:
+  #   - name: scoring-config
+  #     configMap:
+  #       name: scoring-config
+  #   - name: scoring-secret
+  #     secret:
+  #       secretName: scoring-secret
+  extraVolumes: []
+
+  # Additional volume mounts applied to all hub controller containers.
+  # Example:
+  # extraVolumeMounts:
+  #   - name: scoring-config
+  #     mountPath: /etc/dsf/config
+  #     readOnly: true
+  #   - name: scoring-secret
+  #     mountPath: /etc/dsf/secret
+  #     readOnly: true
+  extraVolumeMounts: []
+
   # Namespace where the hub components (e.g. controllers) will be deployed
   namespace: open-cluster-management
 


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary

This PR seeks to modify the Dynamic Scoring Framework helm chart templating to allow specification of additional volumes with the motivating use case being to inject additional ConfigMaps and Secrets volumes to augment the controller's trust store.

While deploying an custom scorer per the example and exposing it over TLS via our cluster ingress, we found the controller was unable to communicate with the custom scorer with an error message `x509: certificate signed by unknown authority` due to our TLS certificate being issued by our internal CA. 

This PR fixes this issue by allowing one to provide a custom configmap with a relevant PEM encoded certificates (or as applicable have said data be injected by [automation](https://docs.redhat.com/en/documentation/openshift_container_platform/4.18/html/configuring_network_settings/configuring-a-custom-pki#certificate-injection-using-operators_configuring-a-custom-pki) and mounting the relevant data over `/etc/ssl/certs` to allow the controller verify the TLS certificate. 

### Example:
**`trusted-ca` Configmap:**
```yaml
kind: ConfigMap
apiVersion: v1
metadata:
  name: trusted-ca
data:
  ca-bundle.crt: |
    # ... trimmed for brevity
```

**`values.yaml` snippet:**
```yaml
hubSetting:
  extraVolumes:
    - name: trusted-ca
      configMap:
        name: trusted-ca
        items:
          - key: ca-bundle.crt 
            path: ca-certificates.crt
     
  extraVolumeMounts:
    - name: trusted-ca
      mountPath: /etc/ssl/certs/
      readOnly: true
```

## Related issue(s)

N/A

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Controllers now support custom pod volumes and container volume mounts, allowing users to inject additional storage/configuration via deployment settings.
  * New configurable values added (with defaults and examples) to enable extraVolumes and extraVolumeMounts for hub controllers, defaulting to empty lists when not provided.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/open-cluster-management-io/addon-contrib/pull/118)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->